### PR TITLE
Materializing spi selection (Trial 2)

### DIFF
--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -19,6 +19,7 @@
 
 #include "common/axis.h"
 #include "drivers/exti.h"
+#include "drivers/io_types.h"
 #include "drivers/sensor.h"
 #include "drivers/accgyro_mpu.h"
 
@@ -49,6 +50,7 @@ typedef struct gyroDev_s {
     sensorGyroInterruptStatusFuncPtr intStatus;
     sensorGyroUpdateFuncPtr update;
     extiCallbackRec_t exti;
+    IO_t spiCsnPin;
     float scale;                                            // scalefactor
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     int32_t gyroZero[XYZ_AXIS_COUNT];
@@ -66,6 +68,7 @@ typedef struct gyroDev_s {
 typedef struct accDev_s {
     sensorAccInitFuncPtr init;                              // initialize function
     sensorAccReadFuncPtr read;                              // read 3 axis data function
+    IO_t spiCsnPin;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -50,7 +50,7 @@ typedef struct gyroDev_s {
     sensorGyroInterruptStatusFuncPtr intStatus;
     sensorGyroUpdateFuncPtr update;
     extiCallbackRec_t exti;
-    sensorSpi_t spi;
+    sensorDev_t dev;
     float scale;                                            // scalefactor
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     int32_t gyroZero[XYZ_AXIS_COUNT];
@@ -68,7 +68,7 @@ typedef struct gyroDev_s {
 typedef struct accDev_s {
     sensorAccInitFuncPtr init;                              // initialize function
     sensorAccReadFuncPtr read;                              // read 3 axis data function
-    sensorSpi_t spi;
+    sensorDev_t dev;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -50,7 +50,7 @@ typedef struct gyroDev_s {
     sensorGyroInterruptStatusFuncPtr intStatus;
     sensorGyroUpdateFuncPtr update;
     extiCallbackRec_t exti;
-    IO_t spiCsnPin;
+    sensorSpi_t spi;
     float scale;                                            // scalefactor
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     int32_t gyroZero[XYZ_AXIS_COUNT];
@@ -68,7 +68,7 @@ typedef struct gyroDev_s {
 typedef struct accDev_s {
     sensorAccInitFuncPtr init;                              // initialize function
     sensorAccReadFuncPtr read;                              // read 3 axis data function
-    IO_t spiCsnPin;
+    sensorSpi_t spi;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -19,7 +19,6 @@
 
 #include "common/axis.h"
 #include "drivers/exti.h"
-#include "drivers/io_types.h"
 #include "drivers/sensor.h"
 #include "drivers/accgyro_mpu.h"
 
@@ -50,7 +49,7 @@ typedef struct gyroDev_s {
     sensorGyroInterruptStatusFuncPtr intStatus;
     sensorGyroUpdateFuncPtr update;
     extiCallbackRec_t exti;
-    sensorDev_t dev;
+    sensorBus_t bus;
     float scale;                                            // scalefactor
     int16_t gyroADCRaw[XYZ_AXIS_COUNT];
     int32_t gyroZero[XYZ_AXIS_COUNT];
@@ -68,7 +67,7 @@ typedef struct gyroDev_s {
 typedef struct accDev_s {
     sensorAccInitFuncPtr init;                              // initialize function
     sensorAccReadFuncPtr read;                              // read 3 axis data function
-    sensorDev_t dev;
+    sensorBus_t bus;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     char revisionCode;                                      // a revision code for the sensor, if known

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -75,7 +75,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
     // See https://android.googlesource.com/kernel/msm.git/+/eaf36994a3992b8f918c18e4f7411e8b2320a35f/drivers/misc/mpu6050/mldl_cfg.c
 
     // determine product ID and accel revision
-    ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU_RA_XA_OFFS_H, 6, readBuffer);
+    ack = gyro->mpuConfiguration.readFn(&gyro->spi, MPU_RA_XA_OFFS_H, 6, readBuffer);
     revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
     if (revision) {
         /* Congrats, these parts are better. */
@@ -89,7 +89,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
             failureMode(FAILURE_ACC_INCOMPATIBLE);
         }
     } else {
-        ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU_RA_PRODUCT_ID, 1, &productId);
+        ack = gyro->mpuConfiguration.readFn(&gyro->spi, MPU_RA_PRODUCT_ID, 1, &productId);
         revision = productId & 0x0F;
         if (!revision) {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
@@ -160,16 +160,16 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
 #endif
 }
 
-static bool mpuReadRegisterI2C(IO_t csnPin, uint8_t reg, uint8_t length, uint8_t* data)
+static bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data)
 {
-    UNUSED(csnPin);
+    UNUSED(spi);
     bool ack = i2cRead(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, length, data);
     return ack;
 }
 
-static bool mpuWriteRegisterI2C(IO_t csnPin, uint8_t reg, uint8_t data)
+static bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
-    UNUSED(csnPin);
+    UNUSED(spi);
     bool ack = i2cWrite(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, data);
     return ack;
 }
@@ -190,7 +190,7 @@ bool mpuAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
-    bool ack = acc->mpuConfiguration.readFn(acc->spi.csnPin, MPU_RA_ACCEL_XOUT_H, 6, data);
+    bool ack = acc->mpuConfiguration.readFn(&acc->spi, MPU_RA_ACCEL_XOUT_H, 6, data);
     if (!ack) {
         return false;
     }
@@ -213,7 +213,7 @@ bool mpuGyroRead(gyroDev_t *gyro)
 {
     uint8_t data[6];
 
-    const bool ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
+    const bool ack = gyro->mpuConfiguration.readFn(&gyro->spi, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
     if (!ack) {
         return false;
     }
@@ -238,15 +238,15 @@ bool mpuCheckDataReady(gyroDev_t* gyro)
 }
 
 #ifdef USE_SPI
-static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCsnPin)
+static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sensorSpi_t *spi)
 {
 #ifdef USE_GYRO_SPI_MPU6000
 #ifdef MPU6000_CS_PIN
-    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : spiCsnPin;
+    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : spi->csnPin;
 #else
-    UNUSED(spiCsnPin);
+    UNUSED(spi);
 #endif
-    if (mpu6000SpiDetect(gyro->spi.csnPin)) {
+    if (mpu6000SpiDetect(&gyro->spi)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6000SpiReadRegister;
@@ -256,8 +256,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6500
-    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : spiCsnPin;
-    if (mpu6500SpiDetect(gyro->spi.csnPin)) {
+    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : spi->csnPin;
+    if (mpu6500SpiDetect(&gyro->spi)) {
         gyro->mpuDetectionResult.sensor = MPU_65xx_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6500SpiReadRegister;
@@ -267,22 +267,22 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
-    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : spiCsnPin;
-    if (mpu9250SpiDetect(gyro->spi.csnPin)) {
+    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : spi->csnPin;
+    if (mpu9250SpiDetect(&gyro->spi)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
-        gyro->mpuConfiguration.readFn = mpu9250ReadRegister;
-        gyro->mpuConfiguration.slowreadFn = mpu9250SlowReadRegister;
-        gyro->mpuConfiguration.verifywriteFn = verifympu9250WriteRegister;
-        gyro->mpuConfiguration.writeFn = mpu9250WriteRegister;
-        gyro->mpuConfiguration.resetFn = mpu9250ResetGyro;
+        gyro->mpuConfiguration.readFn = mpu9250SpiReadRegister;
+        gyro->mpuConfiguration.slowreadFn = mpu9250SpiSlowReadRegister;
+        gyro->mpuConfiguration.verifywriteFn = verifympu9250SpiWriteRegister;
+        gyro->mpuConfiguration.writeFn = mpu9250SpiWriteRegister;
+        gyro->mpuConfiguration.resetFn = mpu9250SpiResetGyro;
         return true;
     }
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
-    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : spiCsnPin;
-    if (icm20689SpiDetect(gyro->spi.csnPin)) {
+    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : spi->csnPin;
+    if (icm20689SpiDetect(&gyro->spi)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = icm20689SpiReadRegister;
@@ -290,13 +290,13 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
         return true;
     }
 #endif
-    UNUSED(spiCsnPin);
+    UNUSED(spi);
     UNUSED(gyro);
     return false;
 }
 #endif
 
-mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, IO_t spiCsnPin)
+mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, const sensorSpi_t *spi)
 {
     // MPU datasheet specifies 30ms.
     delay(35);
@@ -306,15 +306,16 @@ mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, IO_t spiCsnPin)
     bool ack = false;
 #else
     uint8_t sig;
-    bool ack = mpuReadRegisterI2C(IO_NONE, MPU_RA_WHO_AM_I, 1, &sig);
+    bool ack = mpuReadRegisterI2C(NULL, MPU_RA_WHO_AM_I, 1, &sig);
 #endif
     if (ack) {
         gyro->mpuConfiguration.readFn = mpuReadRegisterI2C;
         gyro->mpuConfiguration.writeFn = mpuWriteRegisterI2C;
     } else {
 #ifdef USE_SPI
-        bool detectedSpiSensor = detectSPISensorsAndUpdateDetectionResult(gyro, spiCsnPin);
-        UNUSED(detectedSpiSensor);
+        detectSPISensorsAndUpdateDetectionResult(gyro, spi);
+#else
+        UNUSED(spi);
 #endif
 
         return &gyro->mpuDetectionResult;
@@ -324,7 +325,7 @@ mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, IO_t spiCsnPin)
 
     // If an MPU3050 is connected sig will contain 0.
     uint8_t inquiryResult;
-    ack = mpuReadRegisterI2C(IO_NONE, MPU_RA_WHO_AM_I_LEGACY, 1, &inquiryResult);
+    ack = mpuReadRegisterI2C(NULL, MPU_RA_WHO_AM_I_LEGACY, 1, &inquiryResult);
     inquiryResult &= MPU_INQUIRY_MASK;
     if (ack && inquiryResult == MPUx0x0_WHO_AM_I_CONST) {
         gyro->mpuDetectionResult.sensor = MPU_3050;

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -41,9 +41,10 @@
 #include "accgyro_mpu3050.h"
 #include "accgyro_mpu6050.h"
 #include "accgyro_mpu6500.h"
+#include "accgyro_spi_bmi160.h"
+#include "accgyro_spi_icm20689.h"
 #include "accgyro_spi_mpu6000.h"
 #include "accgyro_spi_mpu6500.h"
-#include "accgyro_spi_icm20689.h"
 #include "accgyro_spi_mpu9250.h"
 #include "accgyro_mpu.h"
 
@@ -278,6 +279,17 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sens
         return true;
     }
 #endif
+
+#ifdef USE_ACCGYRO_BMI160
+    gyro->bus.spi.csnPin = bus->spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : bus->spi.csnPin;
+    if (bmi160Detect(&gyro->bus)) {
+        gyro->mpuDetectionResult.sensor = BMI_160_SPI;
+        gyro->mpuConfiguration.readFn = bmi160SpiReadRegister;
+        gyro->mpuConfiguration.writeFn = bmi160SpiWriteRegister;
+        return true;
+    }
+#endif
+
     UNUSED(bus);
     UNUSED(gyro);
     return false;

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -160,28 +160,16 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
 #endif
 }
 
-static bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data)
+bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data)
 {
     UNUSED(spi);
     bool ack = i2cRead(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, length, data);
     return ack;
 }
 
-static bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
     UNUSED(spi);
-    bool ack = i2cWrite(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, data);
-    return ack;
-}
-
-bool mpuI2CReadRegister(uint8_t reg, uint8_t length, uint8_t *data)
-{
-    bool ack = i2cRead(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, length, data);
-    return ack;
-}
-
-bool mpuI2CWriteRegister(uint8_t reg, uint8_t data)
-{
     bool ack = i2cWrite(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, data);
     return ack;
 }

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -75,7 +75,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
     // See https://android.googlesource.com/kernel/msm.git/+/eaf36994a3992b8f918c18e4f7411e8b2320a35f/drivers/misc/mpu6050/mldl_cfg.c
 
     // determine product ID and accel revision
-    ack = gyro->mpuConfiguration.readFn(&gyro->spi, MPU_RA_XA_OFFS_H, 6, readBuffer);
+    ack = gyro->mpuConfiguration.readFn(&gyro->dev, MPU_RA_XA_OFFS_H, 6, readBuffer);
     revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
     if (revision) {
         /* Congrats, these parts are better. */
@@ -89,7 +89,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
             failureMode(FAILURE_ACC_INCOMPATIBLE);
         }
     } else {
-        ack = gyro->mpuConfiguration.readFn(&gyro->spi, MPU_RA_PRODUCT_ID, 1, &productId);
+        ack = gyro->mpuConfiguration.readFn(&gyro->dev, MPU_RA_PRODUCT_ID, 1, &productId);
         revision = productId & 0x0F;
         if (!revision) {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
@@ -160,16 +160,16 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
 #endif
 }
 
-bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data)
+bool mpuReadRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t* data)
 {
-    UNUSED(spi);
+    UNUSED(dev);
     bool ack = i2cRead(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, length, data);
     return ack;
 }
 
-bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool mpuWriteRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
-    UNUSED(spi);
+    UNUSED(dev);
     bool ack = i2cWrite(MPU_I2C_INSTANCE, MPU_ADDRESS, reg, data);
     return ack;
 }
@@ -178,7 +178,7 @@ bool mpuAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
-    bool ack = acc->mpuConfiguration.readFn(&acc->spi, MPU_RA_ACCEL_XOUT_H, 6, data);
+    bool ack = acc->mpuConfiguration.readFn(&acc->dev, MPU_RA_ACCEL_XOUT_H, 6, data);
     if (!ack) {
         return false;
     }
@@ -201,7 +201,7 @@ bool mpuGyroRead(gyroDev_t *gyro)
 {
     uint8_t data[6];
 
-    const bool ack = gyro->mpuConfiguration.readFn(&gyro->spi, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
+    const bool ack = gyro->mpuConfiguration.readFn(&gyro->dev, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
     if (!ack) {
         return false;
     }
@@ -226,15 +226,15 @@ bool mpuCheckDataReady(gyroDev_t* gyro)
 }
 
 #ifdef USE_SPI
-static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sensorSpi_t *spi)
+static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sensorDev_t *dev)
 {
 #ifdef USE_GYRO_SPI_MPU6000
 #ifdef MPU6000_CS_PIN
-    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : spi->csnPin;
+    gyro->dev.spi.csnPin = dev->spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : dev->spi.csnPin;
 #else
-    UNUSED(spi);
+    UNUSED(dev);
 #endif
-    if (mpu6000SpiDetect(&gyro->spi)) {
+    if (mpu6000SpiDetect(&gyro->dev)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6000SpiReadRegister;
@@ -244,8 +244,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sens
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6500
-    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : spi->csnPin;
-    if (mpu6500SpiDetect(&gyro->spi)) {
+    gyro->dev.spi.csnPin = dev->spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : dev->spi.csnPin;
+    if (mpu6500SpiDetect(&gyro->dev)) {
         gyro->mpuDetectionResult.sensor = MPU_65xx_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6500SpiReadRegister;
@@ -255,8 +255,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sens
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
-    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : spi->csnPin;
-    if (mpu9250SpiDetect(&gyro->spi)) {
+    gyro->dev.spi.csnPin = dev->spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : dev->spi.csnPin;
+    if (mpu9250SpiDetect(&gyro->dev)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu9250SpiReadRegister;
@@ -269,8 +269,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sens
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
-    gyro->spi.csnPin = spi->csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : spi->csnPin;
-    if (icm20689SpiDetect(&gyro->spi)) {
+    gyro->dev.spi.csnPin = dev->spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : dev->spi.csnPin;
+    if (icm20689SpiDetect(&gyro->dev)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = icm20689SpiReadRegister;
@@ -278,13 +278,13 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, const sens
         return true;
     }
 #endif
-    UNUSED(spi);
+    UNUSED(dev);
     UNUSED(gyro);
     return false;
 }
 #endif
 
-mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, const sensorSpi_t *spi)
+mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, const sensorDev_t *dev)
 {
     // MPU datasheet specifies 30ms.
     delay(35);
@@ -301,9 +301,9 @@ mpuDetectionResult_t *mpuDetect(gyroDev_t *gyro, const sensorSpi_t *spi)
         gyro->mpuConfiguration.writeFn = mpuWriteRegisterI2C;
     } else {
 #ifdef USE_SPI
-        detectSPISensorsAndUpdateDetectionResult(gyro, spi);
+        detectSPISensorsAndUpdateDetectionResult(gyro, dev);
 #else
-        UNUSED(spi);
+        UNUSED(dev);
 #endif
 
         return &gyro->mpuDetectionResult;

--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -75,7 +75,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
     // See https://android.googlesource.com/kernel/msm.git/+/eaf36994a3992b8f918c18e4f7411e8b2320a35f/drivers/misc/mpu6050/mldl_cfg.c
 
     // determine product ID and accel revision
-    ack = gyro->mpuConfiguration.readFn(gyro->spiCsnPin, MPU_RA_XA_OFFS_H, 6, readBuffer);
+    ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU_RA_XA_OFFS_H, 6, readBuffer);
     revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
     if (revision) {
         /* Congrats, these parts are better. */
@@ -89,7 +89,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro)
             failureMode(FAILURE_ACC_INCOMPATIBLE);
         }
     } else {
-        ack = gyro->mpuConfiguration.readFn(gyro->spiCsnPin, MPU_RA_PRODUCT_ID, 1, &productId);
+        ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU_RA_PRODUCT_ID, 1, &productId);
         revision = productId & 0x0F;
         if (!revision) {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
@@ -190,7 +190,7 @@ bool mpuAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
-    bool ack = acc->mpuConfiguration.readFn(acc->spiCsnPin, MPU_RA_ACCEL_XOUT_H, 6, data);
+    bool ack = acc->mpuConfiguration.readFn(acc->spi.csnPin, MPU_RA_ACCEL_XOUT_H, 6, data);
     if (!ack) {
         return false;
     }
@@ -213,7 +213,7 @@ bool mpuGyroRead(gyroDev_t *gyro)
 {
     uint8_t data[6];
 
-    const bool ack = gyro->mpuConfiguration.readFn(gyro->spiCsnPin, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
+    const bool ack = gyro->mpuConfiguration.readFn(gyro->spi.csnPin, gyro->mpuConfiguration.gyroReadXRegister, 6, data);
     if (!ack) {
         return false;
     }
@@ -242,11 +242,11 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 {
 #ifdef USE_GYRO_SPI_MPU6000
 #ifdef MPU6000_CS_PIN
-    gyro->spiCsnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : spiCsnPin;
+    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : spiCsnPin;
 #else
     UNUSED(spiCsnPin);
 #endif
-    if (mpu6000SpiDetect(gyro->spiCsnPin)) {
+    if (mpu6000SpiDetect(gyro->spi.csnPin)) {
         gyro->mpuDetectionResult.sensor = MPU_60x0_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6000SpiReadRegister;
@@ -256,8 +256,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 #endif
 
 #ifdef USE_GYRO_SPI_MPU6500
-    gyro->spiCsnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : spiCsnPin;
-    if (mpu6500SpiDetect(gyro->spiCsnPin)) {
+    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : spiCsnPin;
+    if (mpu6500SpiDetect(gyro->spi.csnPin)) {
         gyro->mpuDetectionResult.sensor = MPU_65xx_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu6500SpiReadRegister;
@@ -267,8 +267,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 #endif
 
 #ifdef  USE_GYRO_SPI_MPU9250
-    gyro->spiCsnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : spiCsnPin;
-    if (mpu9250SpiDetect(gyro->spiCsnPin)) {
+    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : spiCsnPin;
+    if (mpu9250SpiDetect(gyro->spi.csnPin)) {
         gyro->mpuDetectionResult.sensor = MPU_9250_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = mpu9250ReadRegister;
@@ -281,8 +281,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro, IO_t spiCs
 #endif
 
 #ifdef USE_GYRO_SPI_ICM20689
-    gyro->spiCsnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : spiCsnPin;
-    if (icm20689SpiDetect(gyro->spiCsnPin)) {
+    gyro->spi.csnPin = spiCsnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : spiCsnPin;
+    if (icm20689SpiDetect(gyro->spi.csnPin)) {
         gyro->mpuDetectionResult.sensor = ICM_20689_SPI;
         gyro->mpuConfiguration.gyroReadXRegister = MPU_RA_GYRO_XOUT_H;
         gyro->mpuConfiguration.readFn = icm20689SpiReadRegister;

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -177,7 +177,8 @@ typedef enum {
     MPU_9250_SPI,
     ICM_20689_SPI,
     ICM_20608_SPI,
-    ICM_20602_SPI
+    ICM_20602_SPI,
+    BMI_160_SPI,
 } mpuSensor_e;
 
 typedef enum {

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -190,8 +190,8 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
-bool mpuI2CReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
-bool mpuI2CWriteRegister(uint8_t reg, uint8_t data);
+bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data);
+bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
 
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -124,8 +124,8 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-typedef bool (*mpuReadRegisterFnPtr)(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t* data);
-typedef bool (*mpuWriteRegisterFnPtr)(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+typedef bool (*mpuReadRegisterFnPtr)(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t* data);
+typedef bool (*mpuWriteRegisterFnPtr)(const sensorBus_t *bus, uint8_t reg, uint8_t data);
 typedef void(*mpuResetFnPtr)(void);
 
 extern mpuResetFnPtr mpuResetFn;
@@ -190,15 +190,15 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
-bool mpuReadRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t* data);
-bool mpuWriteRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool mpuReadRegisterI2C(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t* data);
+bool mpuWriteRegisterI2C(const sensorBus_t *bus, uint8_t reg, uint8_t data);
 
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, const sensorDev_t *dev);
+mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, const sensorBus_t *bus);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);
 void mpuGyroSetIsrUpdate(struct gyroDev_s *gyro, sensorGyroUpdateFuncPtr updateFn);
 

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -124,8 +124,8 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-typedef bool (*mpuReadRegisterFnPtr)(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data);
-typedef bool (*mpuWriteRegisterFnPtr)(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+typedef bool (*mpuReadRegisterFnPtr)(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t* data);
+typedef bool (*mpuWriteRegisterFnPtr)(const sensorDev_t *dev, uint8_t reg, uint8_t data);
 typedef void(*mpuResetFnPtr)(void);
 
 extern mpuResetFnPtr mpuResetFn;
@@ -190,15 +190,15 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
-bool mpuReadRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data);
-bool mpuWriteRegisterI2C(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool mpuReadRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t* data);
+bool mpuWriteRegisterI2C(const sensorDev_t *dev, uint8_t reg, uint8_t data);
 
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, const sensorSpi_t *spi);
+mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, const sensorDev_t *dev);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);
 void mpuGyroSetIsrUpdate(struct gyroDev_s *gyro, sensorGyroUpdateFuncPtr updateFn);
 

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "exti.h"
+#include "io_types.h"
 #include "sensor.h"
 
 //#define DEBUG_MPU_DATA_READY_INTERRUPT
@@ -124,8 +125,8 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-typedef bool (*mpuReadRegisterFnPtr)(uint8_t reg, uint8_t length, uint8_t* data);
-typedef bool (*mpuWriteRegisterFnPtr)(uint8_t reg, uint8_t data);
+typedef bool (*mpuReadRegisterFnPtr)(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t* data);
+typedef bool (*mpuWriteRegisterFnPtr)(IO_t spiCsnPin, uint8_t reg, uint8_t data);
 typedef void(*mpuResetFnPtr)(void);
 
 extern mpuResetFnPtr mpuResetFn;
@@ -190,12 +191,15 @@ typedef struct mpuDetectionResult_s {
     mpu6050Resolution_e resolution;
 } mpuDetectionResult_t;
 
+bool mpuI2CReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool mpuI2CWriteRegister(uint8_t reg, uint8_t data);
+
 struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro);
+mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, IO_t spiCsnPin);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);
 void mpuGyroSetIsrUpdate(struct gyroDev_s *gyro, sensorGyroUpdateFuncPtr updateFn);
 

--- a/src/main/drivers/accgyro_mpu.h
+++ b/src/main/drivers/accgyro_mpu.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "exti.h"
-#include "io_types.h"
 #include "sensor.h"
 
 //#define DEBUG_MPU_DATA_READY_INTERRUPT
@@ -125,8 +124,8 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-typedef bool (*mpuReadRegisterFnPtr)(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t* data);
-typedef bool (*mpuWriteRegisterFnPtr)(IO_t spiCsnPin, uint8_t reg, uint8_t data);
+typedef bool (*mpuReadRegisterFnPtr)(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t* data);
+typedef bool (*mpuWriteRegisterFnPtr)(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
 typedef void(*mpuResetFnPtr)(void);
 
 extern mpuResetFnPtr mpuResetFn;
@@ -199,7 +198,7 @@ void mpuGyroInit(struct gyroDev_s *gyro);
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);
 bool mpuGyroRead(struct gyroDev_s *gyro);
-mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, IO_t spiCsnPin);
+mpuDetectionResult_t *mpuDetect(struct gyroDev_s *gyro, const sensorSpi_t *spi);
 bool mpuCheckDataReady(struct gyroDev_s *gyro);
 void mpuGyroSetIsrUpdate(struct gyroDev_s *gyro, sensorGyroUpdateFuncPtr updateFn);
 

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -53,20 +53,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.writeFn(&gyro->bus, MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_INT_CFG, 0);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
     uint8_t buf[2];
-    if (!gyro->mpuConfiguration.readFn(&gyro->dev, MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.readFn(&gyro->bus, MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -53,20 +53,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_INT_CFG, 0);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
     uint8_t buf[2];
-    if (!gyro->mpuConfiguration.readFn(gyro->spiCsnPin, MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -53,21 +53,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = gyro->mpuConfiguration.writeFn(MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    gyro->mpuConfiguration.writeFn(MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    gyro->mpuConfiguration.writeFn(MPU3050_INT_CFG, 0);
-    gyro->mpuConfiguration.writeFn(MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    gyro->mpuConfiguration.writeFn(MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
-    UNUSED(gyro);
     uint8_t buf[2];
-    if (!gyro->mpuConfiguration.readFn(MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.readFn(gyro->spiCsnPin, MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -53,20 +53,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_INT_CFG, 0);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
     uint8_t buf[2];
-    if (!gyro->mpuConfiguration.readFn(&gyro->spi, MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.readFn(&gyro->dev, MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro_mpu3050.c
@@ -53,20 +53,20 @@ static void mpu3050Init(gyroDev_t *gyro)
 
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
 
-    ack = gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_SMPLRT_DIV, 0);
+    ack = gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_SMPLRT_DIV, 0);
     if (!ack)
         failureMode(FAILURE_ACC_INIT);
 
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_INT_CFG, 0);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_INT_CFG, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData)
 {
     uint8_t buf[2];
-    if (!gyro->mpuConfiguration.readFn(gyro->spi.csnPin, MPU3050_TEMP_OUT, 2, buf)) {
+    if (!gyro->mpuConfiguration.readFn(&gyro->spi, MPU3050_TEMP_OUT, 2, buf)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -79,23 +79,23 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG,
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -79,23 +79,23 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    gyro->mpuConfiguration.writeFn(MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    gyro->mpuConfiguration.writeFn(MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    gyro->mpuConfiguration.writeFn(MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    gyro->mpuConfiguration.writeFn(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    gyro->mpuConfiguration.writeFn(MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    gyro->mpuConfiguration.writeFn(MPU_RA_INT_PIN_CFG,
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -79,23 +79,23 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG,
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -79,23 +79,23 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG,
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -79,23 +79,23 @@ static void mpu6050GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
 
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG,
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG,
             0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -55,34 +55,34 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -55,34 +55,34 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(&gyro->bus, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -55,34 +55,34 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -55,34 +55,34 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -55,34 +55,34 @@ void mpu6500GyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    gyro->mpuConfiguration.writeFn(MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    gyro->mpuConfiguration.writeFn(MPU_RA_PWR_MGMT_1, 0);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    gyro->mpuConfiguration.writeFn(MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    gyro->mpuConfiguration.writeFn(MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    gyro->mpuConfiguration.writeFn(MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro_spi_bmi160.c
@@ -360,9 +360,9 @@ bool bmi160AccRead(accDev_t *acc)
     uint8_t bmi160_rec_buf[BUFFER_SIZE];
     uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
 
-    ENABLE_BMI160(acc->spiCsnPin);
+    ENABLE_BMI160(acc->spi.csnPin);
     spiTransfer(BMI160_SPI_INSTANCE, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
-    DISABLE_BMI160(acc->spiCsnPin);
+    DISABLE_BMI160(acc->spi.csnPin);
 
     acc->ADCRaw[X] = (int16_t)((bmi160_rec_buf[IDX_ACCEL_XOUT_H] << 8) | bmi160_rec_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi160_rec_buf[IDX_ACCEL_YOUT_H] << 8) | bmi160_rec_buf[IDX_ACCEL_YOUT_L]);
@@ -388,9 +388,9 @@ bool bmi160GyroRead(gyroDev_t *gyro)
     uint8_t bmi160_rec_buf[BUFFER_SIZE];
     uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
 
-    ENABLE_BMI160(gyro->spiCsnPin);
+    ENABLE_BMI160(gyro->spi.csnPin);
     spiTransfer(BMI160_SPI_INSTANCE, bmi160_rec_buf, bmi160_tx_buf, BUFFER_SIZE);   // receive response
-    DISABLE_BMI160(gyro->spiCsnPin);
+    DISABLE_BMI160(gyro->spi.csnPin);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi160_rec_buf[IDX_GYRO_XOUT_H] << 8) | bmi160_rec_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi160_rec_buf[IDX_GYRO_YOUT_H] << 8) | bmi160_rec_buf[IDX_GYRO_YOUT_L]);
@@ -414,13 +414,13 @@ bool checkBMI160DataReady(gyroDev_t* gyro)
 
 void bmi160SpiGyroInit(gyroDev_t *gyro)
 {
-    BMI160_Init(gyro->spiCsnPin);
+    BMI160_Init(gyro->spi.csnPin);
     bmi160IntExtiInit(gyro);
 }
 
 void bmi160SpiAccInit(accDev_t *acc)
 {
-    BMI160_Init(acc->spiCsnPin);
+    BMI160_Init(acc->spi.csnPin);
 
     acc->acc_1G = 512 * 8;
 }
@@ -428,7 +428,7 @@ void bmi160SpiAccInit(accDev_t *acc)
 
 bool bmi160SpiAccDetect(accDev_t *acc)
 {
-    if (!BMI160_Detect(acc->spiCsnPin)) {
+    if (!BMI160_Detect(acc->spi.csnPin)) {
         return false;
     }
 
@@ -441,7 +441,7 @@ bool bmi160SpiAccDetect(accDev_t *acc)
 
 bool bmi160SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (!BMI160_Detect(gyro->spiCsnPin)) {
+    if (!BMI160_Detect(gyro->spi.csnPin)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro_spi_bmi160.c
@@ -97,7 +97,7 @@ static int32_t BMI160_WriteReg(const sensorBus_t *bus, uint8_t reg, uint8_t data
 #define ENABLE_BMI160(spiCsnPin)        IOLo(spiCsnPin)
 
 
-bool BMI160_Detect(const sensorBus_t *bus)
+bool bmi160Detect(const sensorBus_t *bus)
 {
     if (BMI160Detected)
         return true;
@@ -273,7 +273,7 @@ static int32_t BMI160_do_foc(const sensorBus_t *bus)
  * @returns The register value
  * @param reg[in] Register address to be read
  */
-static uint8_t BMI160_ReadReg(const sensorBus_t *bus, uint8_t reg)
+uint8_t BMI160_ReadReg(const sensorBus_t *bus, uint8_t reg)
 {
     uint8_t data;
 
@@ -287,6 +287,15 @@ static uint8_t BMI160_ReadReg(const sensorBus_t *bus, uint8_t reg)
     return data;
 }
 
+bool bmi160SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
+{
+    ENABLE_BMI160(bus->spi.csnPin);
+    spiTransferByte(BMI160_SPI_INSTANCE, reg | 0x80); // read transaction
+    spiTransfer(BMI160_SPI_INSTANCE, data, NULL, length);
+    ENABLE_BMI160(bus->spi.csnPin);
+
+    return true;
+}
 
 /**
  * @brief Writes one byte to the BMI160 register
@@ -306,6 +315,10 @@ static int32_t BMI160_WriteReg(const sensorBus_t *bus, uint8_t reg, uint8_t data
     return 0;
 }
 
+bool bmi160SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data)
+{
+    return BMI160_WriteReg(bus, reg, data);
+}
 
 extiCallbackRec_t bmi160IntCallbackRec;
 
@@ -420,7 +433,7 @@ void bmi160SpiAccInit(accDev_t *acc)
 
 bool bmi160SpiAccDetect(accDev_t *acc)
 {
-    if (!BMI160_Detect(acc->bus.spi.csnPin)) {
+    if (!bmi160Detect(acc->bus.spi.csnPin)) {
         return false;
     }
 
@@ -433,7 +446,7 @@ bool bmi160SpiAccDetect(accDev_t *acc)
 
 bool bmi160SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (!BMI160_Detect(gyro->bus.spi.csnPin)) {
+    if (!bmi160Detect(gyro->bus.spi.csnPin)) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro_spi_bmi160.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "io_types.h"
+
 enum pios_bmi160_orientation { // clockwise rotation from board forward
     PIOS_BMI160_TOP_0DEG,
     PIOS_BMI160_TOP_90DEG,
@@ -66,5 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
+bool BMI160_Detect(IO_t spiCsnPin);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro_spi_bmi160.h
@@ -68,6 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-bool BMI160_Detect(const sensorDev_t *dev);
+bool BMI160_Detect(const sensorBus_t *bus);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro_spi_bmi160.h
@@ -68,6 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-bool BMI160_Detect(const sensorSpi_t *spi);
+bool BMI160_Detect(const sensorDev_t *dev);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro_spi_bmi160.h
@@ -68,6 +68,9 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-bool BMI160_Detect(const sensorBus_t *bus);
+bool bmi160SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool bmi160SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+
+bool bmi160Detect(const sensorBus_t *bus);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro_spi_bmi160.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "io_types.h"
+#include "sensor.h"
 
 enum pios_bmi160_orientation { // clockwise rotation from board forward
     PIOS_BMI160_TOP_0DEG,
@@ -68,6 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-bool BMI160_Detect(IO_t spiCsnPin);
+bool BMI160_Detect(const sensorSpi_t *spi);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro_spi_icm20689.c
@@ -39,27 +39,27 @@
 #define DISABLE_ICM20689(spiCsnPin)       IOHi(spiCsnPin)
 #define ENABLE_ICM20689(spiCsnPin)        IOLo(spiCsnPin)
 
-bool icm20689SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool icm20689SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
-    ENABLE_ICM20689(spi->csnPin);
+    ENABLE_ICM20689(dev->spi.csnPin);
     spiTransferByte(ICM20689_SPI_INSTANCE, reg);
     spiTransferByte(ICM20689_SPI_INSTANCE, data);
-    DISABLE_ICM20689(spi->csnPin);
+    DISABLE_ICM20689(dev->spi.csnPin);
 
     return true;
 }
 
-bool icm20689SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
+bool icm20689SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_ICM20689(spi->csnPin);
+    ENABLE_ICM20689(dev->spi.csnPin);
     spiTransferByte(ICM20689_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(ICM20689_SPI_INSTANCE, data, NULL, length);
-    DISABLE_ICM20689(spi->csnPin);
+    DISABLE_ICM20689(dev->spi.csnPin);
 
     return true;
 }
 
-static void icm20689SpiInit(const sensorSpi_t *spi)
+static void icm20689SpiInit(const sensorDev_t *dev)
 {
     static bool hardwareInitialised = false;
 
@@ -67,15 +67,15 @@ static void icm20689SpiInit(const sensorSpi_t *spi)
         return;
     }
 
-    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
+    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_STANDARD);
 
     hardwareInitialised = true;
 }
 
-bool icm20689SpiDetect(const sensorSpi_t *spi)
+bool icm20689SpiDetect(const sensorDev_t *dev)
 {
     uint8_t tmp;
     uint8_t attemptsRemaining = 20;
@@ -84,12 +84,12 @@ bool icm20689SpiDetect(const sensorSpi_t *spi)
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
 
-    icm20689SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    icm20689SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
 
     do {
         delay(150);
 
-        icm20689SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &tmp);
+        icm20689SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &tmp);
         if (tmp == ICM20689_WHO_AM_I_CONST) {
             break;
         }
@@ -127,32 +127,32 @@ void icm20689GyroInit(gyroDev_t *gyro)
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, 0x03);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
     delay(100);
-//    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0);
+//    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
 //    delay(100);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
-//    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
+//    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_STANDARD);

--- a/src/main/drivers/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro_spi_icm20689.c
@@ -36,30 +36,30 @@
 #include "accgyro_mpu.h"
 #include "accgyro_spi_icm20689.h"
 
-#define DISABLE_ICM20689       IOHi(spiCsnPin)
-#define ENABLE_ICM20689        IOLo(spiCsnPin)
+#define DISABLE_ICM20689(spiCsnPin)       IOHi(spiCsnPin)
+#define ENABLE_ICM20689(spiCsnPin)        IOLo(spiCsnPin)
 
-bool icm20689SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
+bool icm20689SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
-    ENABLE_ICM20689;
+    ENABLE_ICM20689(spi->csnPin);
     spiTransferByte(ICM20689_SPI_INSTANCE, reg);
     spiTransferByte(ICM20689_SPI_INSTANCE, data);
-    DISABLE_ICM20689;
+    DISABLE_ICM20689(spi->csnPin);
 
     return true;
 }
 
-bool icm20689SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
+bool icm20689SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_ICM20689;
+    ENABLE_ICM20689(spi->csnPin);
     spiTransferByte(ICM20689_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(ICM20689_SPI_INSTANCE, data, NULL, length);
-    DISABLE_ICM20689;
+    DISABLE_ICM20689(spi->csnPin);
 
     return true;
 }
 
-static void icm20689SpiInit(IO_t spiCsnPin)
+static void icm20689SpiInit(const sensorSpi_t *spi)
 {
     static bool hardwareInitialised = false;
 
@@ -67,29 +67,29 @@ static void icm20689SpiInit(IO_t spiCsnPin)
         return;
     }
 
-    IOInit(spiCsnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spiCsnPin, SPI_IO_CS_CFG);
+    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_STANDARD);
 
     hardwareInitialised = true;
 }
 
-bool icm20689SpiDetect(IO_t spiCsnPin)
+bool icm20689SpiDetect(const sensorSpi_t *spi)
 {
     uint8_t tmp;
     uint8_t attemptsRemaining = 20;
 
-    icm20689SpiInit(spiCsnPin);
+    icm20689SpiInit(spi);
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
 
-    icm20689SpiWriteRegister(spiCsnPin, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    icm20689SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
 
     do {
         delay(150);
 
-        icm20689SpiReadRegister(spiCsnPin, MPU_RA_WHO_AM_I, 1, &tmp);
+        icm20689SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &tmp);
         if (tmp == ICM20689_WHO_AM_I_CONST) {
             break;
         }
@@ -127,32 +127,32 @@ void icm20689GyroInit(gyroDev_t *gyro)
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, 0x03);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, 0x03);
     delay(100);
-//    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0);
+//    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, 0);
 //    delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
-//    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
+//    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(&gyro->spi, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_STANDARD);

--- a/src/main/drivers/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro_spi_icm20689.c
@@ -127,32 +127,32 @@ void icm20689GyroInit(gyroDev_t *gyro)
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SIGNAL_PATH_RESET, 0x03);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, 0x03);
     delay(100);
-//    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, 0);
+//    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, 0);
 //    delay(100);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_CONFIG, gyro->lpf);
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_CONFIG, gyro->lpf);
     delay(15);
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro)); // Get Divider Drops
     delay(100);
 
     // Data ready interrupt configuration
-//    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
+//    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
     delay(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    gyro->mpuConfiguration.writeFn(gyro->spiCsnPin, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    gyro->mpuConfiguration.writeFn(gyro->spi.csnPin, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
 
     spiSetDivisor(ICM20689_SPI_INSTANCE, SPI_CLOCK_STANDARD);

--- a/src/main/drivers/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro_spi_icm20689.h
@@ -27,10 +27,10 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-bool icm20689SpiDetect(const sensorSpi_t *spi);
+bool icm20689SpiDetect(const sensorDev_t *dev);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);
 
-bool icm20689SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
-bool icm20689SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
+bool icm20689SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool icm20689SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro_spi_icm20689.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "io_types.h"
+#include "sensor.h"
 
 #define ICM20689_WHO_AM_I_CONST             (0x98)
 #define ICM20689_BIT_RESET                  (0x80)
@@ -27,10 +27,10 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-bool icm20689SpiDetect(IO_t mpuSpiCsPin);
+bool icm20689SpiDetect(const sensorSpi_t *spi);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);
 
-bool icm20689SpiWriteRegister(IO_t icmSpiCsPin, uint8_t reg, uint8_t data);
-bool icm20689SpiReadRegister(IO_t icmSpiCsPin, uint8_t reg, uint8_t length, uint8_t *data);
+bool icm20689SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool icm20689SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro_spi_icm20689.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include "io_types.h"
+
 #define ICM20689_WHO_AM_I_CONST             (0x98)
 #define ICM20689_BIT_RESET                  (0x80)
 
@@ -25,10 +27,10 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-bool icm20689SpiDetect(void);
+bool icm20689SpiDetect(IO_t mpuSpiCsPin);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);
 
-bool icm20689WriteRegister(uint8_t reg, uint8_t data);
-bool icm20689ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool icm20689SpiWriteRegister(IO_t icmSpiCsPin, uint8_t reg, uint8_t data);
+bool icm20689SpiReadRegister(IO_t icmSpiCsPin, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro_spi_icm20689.h
@@ -27,10 +27,10 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-bool icm20689SpiDetect(const sensorDev_t *dev);
+bool icm20689SpiDetect(const sensorBus_t *bus);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);
 
-bool icm20689SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
-bool icm20689SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
+bool icm20689SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool icm20689SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -99,12 +99,10 @@ static bool mpuSpi6000InitDone = false;
 #define MPU6000_REV_D9 0x59
 #define MPU6000_REV_D10 0x5A
 
-#define DISABLE_MPU6000       IOHi(mpuSpi6000CsPin)
-#define ENABLE_MPU6000        IOLo(mpuSpi6000CsPin)
+#define DISABLE_MPU6000       IOHi(spiCsnPin)
+#define ENABLE_MPU6000        IOLo(spiCsnPin)
 
-static IO_t mpuSpi6000CsPin = IO_NONE;
-
-bool mpu6000WriteRegister(uint8_t reg, uint8_t data)
+bool mpu6000SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
 {
     ENABLE_MPU6000;
     spiTransferByte(MPU6000_SPI_INSTANCE, reg);
@@ -114,7 +112,7 @@ bool mpu6000WriteRegister(uint8_t reg, uint8_t data)
     return true;
 }
 
-bool mpu6000ReadRegister(uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6000SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
 {
     ENABLE_MPU6000;
     spiTransferByte(MPU6000_SPI_INSTANCE, reg | 0x80); // read transaction
@@ -133,7 +131,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000WriteRegister(MPU6000_CONFIG, gyro->lpf);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -150,25 +148,22 @@ void mpu6000SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu6000SpiDetect(void)
+bool mpu6000SpiDetect(IO_t spiCsnPin)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 5;
 
-#ifdef MPU6000_CS_PIN
-    mpuSpi6000CsPin = IOGetByTag(IO_TAG(MPU6000_CS_PIN));
-#endif
-    IOInit(mpuSpi6000CsPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(mpuSpi6000CsPin, SPI_IO_CS_CFG);
+    IOInit(spiCsnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(spiCsnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    mpu6000WriteRegister(MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(spiCsnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     do {
         delay(150);
 
-        mpu6000ReadRegister(MPU_RA_WHO_AM_I, 1, &in);
+        mpu6000SpiReadRegister(spiCsnPin, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -177,7 +172,7 @@ bool mpu6000SpiDetect(void)
         }
     } while (attemptsRemaining--);
 
-    mpu6000ReadRegister(MPU_RA_PRODUCT_ID, 1, &in);
+    mpu6000SpiReadRegister(spiCsnPin, MPU_RA_PRODUCT_ID, 1, &in);
 
     /* look for a product ID we recognise */
 
@@ -210,41 +205,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000WriteRegister(MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000WriteRegister(MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000WriteRegister(MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000WriteRegister(MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000WriteRegister(MPU_RA_PWR_MGMT_2, 0x00);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000WriteRegister(MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000WriteRegister(MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000WriteRegister(MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000WriteRegister(MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000WriteRegister(MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -131,7 +131,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU6000_CONFIG, gyro->lpf);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -205,41 +205,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_2, 0x00);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000SpiWriteRegister(gyro->spiCsnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -102,22 +102,22 @@ static bool mpuSpi6000InitDone = false;
 #define DISABLE_MPU6000(spiCsnPin)       IOHi(spiCsnPin)
 #define ENABLE_MPU6000(spiCsnPin)        IOLo(spiCsnPin)
 
-bool mpu6000SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool mpu6000SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6000(spi->csnPin);
+    ENABLE_MPU6000(dev->spi.csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg);
     spiTransferByte(MPU6000_SPI_INSTANCE, data);
-    DISABLE_MPU6000(spi->csnPin);
+    DISABLE_MPU6000(dev->spi.csnPin);
 
     return true;
 }
 
-bool mpu6000SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6000SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6000(spi->csnPin);
+    ENABLE_MPU6000(dev->spi.csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6000_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6000(spi->csnPin);
+    DISABLE_MPU6000(dev->spi.csnPin);
 
     return true;
 }
@@ -131,7 +131,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000SpiWriteRegister(&gyro->spi, MPU6000_CONFIG, gyro->lpf);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -148,22 +148,22 @@ void mpu6000SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu6000SpiDetect(const sensorSpi_t *spi)
+bool mpu6000SpiDetect(const sensorDev_t *dev)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 5;
 
-    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
+    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    mpu6000SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     do {
         delay(150);
 
-        mpu6000SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &in);
+        mpu6000SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -172,7 +172,7 @@ bool mpu6000SpiDetect(const sensorSpi_t *spi)
         }
     } while (attemptsRemaining--);
 
-    mpu6000SpiReadRegister(spi, MPU_RA_PRODUCT_ID, 1, &in);
+    mpu6000SpiReadRegister(dev, MPU_RA_PRODUCT_ID, 1, &in);
 
     /* look for a product ID we recognise */
 
@@ -205,41 +205,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_2, 0x00);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -102,22 +102,22 @@ static bool mpuSpi6000InitDone = false;
 #define DISABLE_MPU6000(spiCsnPin)       IOHi(spiCsnPin)
 #define ENABLE_MPU6000(spiCsnPin)        IOLo(spiCsnPin)
 
-bool mpu6000SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
+bool mpu6000SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6000(dev->spi.csnPin);
+    ENABLE_MPU6000(bus->spi.csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg);
     spiTransferByte(MPU6000_SPI_INSTANCE, data);
-    DISABLE_MPU6000(dev->spi.csnPin);
+    DISABLE_MPU6000(bus->spi.csnPin);
 
     return true;
 }
 
-bool mpu6000SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6000SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6000(dev->spi.csnPin);
+    ENABLE_MPU6000(bus->spi.csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6000_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6000(dev->spi.csnPin);
+    DISABLE_MPU6000(bus->spi.csnPin);
 
     return true;
 }
@@ -131,7 +131,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000SpiWriteRegister(&gyro->dev, MPU6000_CONFIG, gyro->lpf);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -148,22 +148,22 @@ void mpu6000SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu6000SpiDetect(const sensorDev_t *dev)
+bool mpu6000SpiDetect(const sensorBus_t *bus)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 5;
 
-    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
+    IOInit(bus->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    mpu6000SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     do {
         delay(150);
 
-        mpu6000SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &in);
+        mpu6000SpiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -172,7 +172,7 @@ bool mpu6000SpiDetect(const sensorDev_t *dev)
         }
     } while (attemptsRemaining--);
 
-    mpu6000SpiReadRegister(dev, MPU_RA_PRODUCT_ID, 1, &in);
+    mpu6000SpiReadRegister(bus, MPU_RA_PRODUCT_ID, 1, &in);
 
     /* look for a product ID we recognise */
 
@@ -205,41 +205,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_2, 0x00);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000SpiWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    mpu6000SpiWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -99,25 +99,25 @@ static bool mpuSpi6000InitDone = false;
 #define MPU6000_REV_D9 0x59
 #define MPU6000_REV_D10 0x5A
 
-#define DISABLE_MPU6000       IOHi(spiCsnPin)
-#define ENABLE_MPU6000        IOLo(spiCsnPin)
+#define DISABLE_MPU6000(spiCsnPin)       IOHi(spiCsnPin)
+#define ENABLE_MPU6000(spiCsnPin)        IOLo(spiCsnPin)
 
-bool mpu6000SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
+bool mpu6000SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6000;
+    ENABLE_MPU6000(spi->csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg);
     spiTransferByte(MPU6000_SPI_INSTANCE, data);
-    DISABLE_MPU6000;
+    DISABLE_MPU6000(spi->csnPin);
 
     return true;
 }
 
-bool mpu6000SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6000SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6000;
+    ENABLE_MPU6000(spi->csnPin);
     spiTransferByte(MPU6000_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6000_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6000;
+    DISABLE_MPU6000(spi->csnPin);
 
     return true;
 }
@@ -131,7 +131,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Accel and Gyro DLPF Setting
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU6000_CONFIG, gyro->lpf);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU6000_CONFIG, gyro->lpf);
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_FAST);  // 18 MHz SPI clock
@@ -148,22 +148,22 @@ void mpu6000SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu6000SpiDetect(IO_t spiCsnPin)
+bool mpu6000SpiDetect(const sensorSpi_t *spi)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 5;
 
-    IOInit(spiCsnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spiCsnPin, SPI_IO_CS_CFG);
+    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
-    mpu6000SpiWriteRegister(spiCsnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
 
     do {
         delay(150);
 
-        mpu6000SpiReadRegister(spiCsnPin, MPU_RA_WHO_AM_I, 1, &in);
+        mpu6000SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -172,7 +172,7 @@ bool mpu6000SpiDetect(IO_t spiCsnPin)
         }
     } while (attemptsRemaining--);
 
-    mpu6000SpiReadRegister(spiCsnPin, MPU_RA_PRODUCT_ID, 1, &in);
+    mpu6000SpiReadRegister(spi, MPU_RA_PRODUCT_ID, 1, &in);
 
     /* look for a product ID we recognise */
 
@@ -205,41 +205,41 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro)
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON);
 
     // Device Reset
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
 
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
 
     // Clock Source PPL with Z axis gyro reference
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
 
     // Disable Primary I2C Interface
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_2, 0x00);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
 
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
     delayMicroseconds(15);
 
     // Gyro +/- 1000 DPS Full Scale
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
 
     // Accel +/- 8 G Full Scale
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
     delayMicroseconds(15);
 
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    mpu6000SpiWriteRegister(gyro->spi.csnPin, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    mpu6000SpiWriteRegister(&gyro->spi, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
 

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "io_types.h"
+
 #define MPU6000_CONFIG              0x1A
 
 #define BITS_DLPF_CFG_256HZ         0x00
@@ -15,10 +17,10 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-bool mpu6000SpiDetect(void);
+bool mpu6000SpiDetect(IO_t mpuCsPin);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6000WriteRegister(uint8_t reg, uint8_t data);
-bool mpu6000ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6000SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
+bool mpu6000SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "io_types.h"
+#include "sensor.h"
 
 #define MPU6000_CONFIG              0x1A
 
@@ -17,10 +17,10 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-bool mpu6000SpiDetect(IO_t mpuCsPin);
+bool mpu6000SpiDetect(const sensorSpi_t *spi);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6000SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
-bool mpu6000SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6000SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool mpu6000SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -17,10 +17,10 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-bool mpu6000SpiDetect(const sensorSpi_t *spi);
+bool mpu6000SpiDetect(const sensorDev_t *dev);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6000SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
-bool mpu6000SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6000SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool mpu6000SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -17,10 +17,10 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-bool mpu6000SpiDetect(const sensorDev_t *dev);
+bool mpu6000SpiDetect(const sensorBus_t *bus);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6000SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
-bool mpu6000SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6000SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool mpu6000SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -75,8 +75,7 @@ static void mpu6500SpiInit(const sensorBus_t *bus)
     hardwareInitialised = true;
 }
 
-static uint8_t mpuDetected = MPU_NONE;
-uint8_t mpu6500SpiDetect(const sensorBus_t *bus)
+bool mpu6500SpiDetect(const sensorBus_t *bus)
 {
     uint8_t tmp;
 
@@ -86,22 +85,15 @@ uint8_t mpu6500SpiDetect(const sensorBus_t *bus)
 
     switch (tmp) {
     case MPU6500_WHO_AM_I_CONST:
-        mpuDetected = MPU_65xx_SPI;
-        break;
     case MPU9250_WHO_AM_I_CONST:
     case MPU9255_WHO_AM_I_CONST:
-        mpuDetected = MPU_9250_SPI;
-        break;
     case ICM20608G_WHO_AM_I_CONST:
-        mpuDetected = ICM_20608_SPI;
-        break;
     case ICM20602_WHO_AM_I_CONST:
-        mpuDetected = ICM_20602_SPI;
-        break;
+        return true;
+
     default:
-        mpuDetected = MPU_NONE;
+        return false;
     }
-    return mpuDetected;
 }
 
 void mpu6500SpiAccInit(accDev_t *acc)
@@ -126,7 +118,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
 
 bool mpu6500SpiAccDetect(accDev_t *acc)
 {
-    if (acc->mpuDetectionResult.sensor != mpuDetected || !mpuDetected) {
+    if (acc->mpuDetectionResult.sensor != MPU_65xx_SPI) {
         return false;
     }
 
@@ -138,7 +130,7 @@ bool mpu6500SpiAccDetect(accDev_t *acc)
 
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro)
 {
-    if (gyro->mpuDetectionResult.sensor != mpuDetected || !mpuDetected) {
+    if (gyro->mpuDetectionResult.sensor != MPU_65xx_SPI) {
         return false;
     }
 

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -76,14 +76,13 @@ static void mpu6500SpiInit(IO_t spiCsnPin)
 }
 
 static uint8_t mpuDetected = MPU_NONE;
-uint8_t mpu6500SpiDetect(IO_t mpuCsPin)
+uint8_t mpu6500SpiDetect(IO_t spiCsnPin)
 {
-<<<<<<< HEAD
     uint8_t tmp;
 
-    mpu6500SpiInit();
+    mpu6500SpiInit(spiCsnPin);
 
-    mpu6500ReadRegister(MPU_RA_WHO_AM_I, 1, &tmp);
+    mpu6500SpiReadRegister(spiCsnPin, MPU_RA_WHO_AM_I, 1, &tmp);
 
     switch (tmp) {
     case MPU6500_WHO_AM_I_CONST:
@@ -101,38 +100,6 @@ uint8_t mpu6500SpiDetect(IO_t mpuCsPin)
         break;
     default:
         mpuDetected = MPU_NONE;
-=======
-    mpu6500SpiInit(mpuCsPin);
-
-    uint8_t tmp;
-    uint8_t detectRetries = 0;
-    delayMicroseconds(15);
-    do {
-        mpu6500SpiReadRegister(mpuCsPin, MPU_RA_PWR_MGMT_1, 1, &tmp);
-        detectRetries++;
-    } while (tmp != BIT_SLEEP && detectRetries < 30);
-
-    if (tmp == BIT_SLEEP) {
-        mpu6500SpiReadRegister(mpuCsPin, MPU_RA_WHO_AM_I, 1, &tmp);
-        delayMicroseconds(15);
-        switch (tmp) {
-        case MPU6500_WHO_AM_I_CONST:
-            mpuDetected = MPU_65xx_SPI;
-            break;
-        case MPU9250_WHO_AM_I_CONST:
-        case MPU9255_WHO_AM_I_CONST:
-            mpuDetected = MPU_9250_SPI;
-            break;
-        case ICM20608G_WHO_AM_I_CONST:
-            mpuDetected = ICM_20608_SPI;
-            break;
-        case ICM20602_WHO_AM_I_CONST:
-            mpuDetected = ICM_20602_SPI;
-            break;
-        default:
-            mpuDetected = MPU_NONE;
-        }
->>>>>>> Added runtime setting of gyro SPI pin
     }
     return mpuDetected;
 }
@@ -150,7 +117,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    mpu6500SpiWriteRegister(gyro->spiCsnPin, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    mpu6500SpiWriteRegister(gyro->spi.csnPin, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -39,27 +39,27 @@
 
 #define BIT_SLEEP                   0x40
 
-bool mpu6500SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool mpu6500SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6500(spi->csnPin);
+    ENABLE_MPU6500(dev->spi.csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg);
     spiTransferByte(MPU6500_SPI_INSTANCE, data);
-    DISABLE_MPU6500(spi->csnPin);
+    DISABLE_MPU6500(dev->spi.csnPin);
 
     return true;
 }
 
-bool mpu6500SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6500SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6500(spi->csnPin);
+    ENABLE_MPU6500(dev->spi.csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6500_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6500(spi->csnPin);
+    DISABLE_MPU6500(dev->spi.csnPin);
 
     return true;
 }
 
-static void mpu6500SpiInit(const sensorSpi_t *spi)
+static void mpu6500SpiInit(const sensorDev_t *dev)
 {
     static bool hardwareInitialised = false;
 
@@ -67,8 +67,8 @@ static void mpu6500SpiInit(const sensorSpi_t *spi)
         return;
     }
 
-    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
+    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
 
@@ -76,13 +76,13 @@ static void mpu6500SpiInit(const sensorSpi_t *spi)
 }
 
 static uint8_t mpuDetected = MPU_NONE;
-uint8_t mpu6500SpiDetect(const sensorSpi_t *spi)
+uint8_t mpu6500SpiDetect(const sensorDev_t *dev)
 {
     uint8_t tmp;
 
-    mpu6500SpiInit(spi);
+    mpu6500SpiInit(dev);
 
-    mpu6500SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &tmp);
+    mpu6500SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &tmp);
 
     switch (tmp) {
     case MPU6500_WHO_AM_I_CONST:
@@ -117,7 +117,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    mpu6500SpiWriteRegister(&gyro->spi, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    mpu6500SpiWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -39,27 +39,27 @@
 
 #define BIT_SLEEP                   0x40
 
-bool mpu6500SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
+bool mpu6500SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6500(dev->spi.csnPin);
+    ENABLE_MPU6500(bus->spi.csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg);
     spiTransferByte(MPU6500_SPI_INSTANCE, data);
-    DISABLE_MPU6500(dev->spi.csnPin);
+    DISABLE_MPU6500(bus->spi.csnPin);
 
     return true;
 }
 
-bool mpu6500SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6500SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6500(dev->spi.csnPin);
+    ENABLE_MPU6500(bus->spi.csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6500_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6500(dev->spi.csnPin);
+    DISABLE_MPU6500(bus->spi.csnPin);
 
     return true;
 }
 
-static void mpu6500SpiInit(const sensorDev_t *dev)
+static void mpu6500SpiInit(const sensorBus_t *bus)
 {
     static bool hardwareInitialised = false;
 
@@ -67,8 +67,8 @@ static void mpu6500SpiInit(const sensorDev_t *dev)
         return;
     }
 
-    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
+    IOInit(bus->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
 
@@ -76,13 +76,13 @@ static void mpu6500SpiInit(const sensorDev_t *dev)
 }
 
 static uint8_t mpuDetected = MPU_NONE;
-uint8_t mpu6500SpiDetect(const sensorDev_t *dev)
+uint8_t mpu6500SpiDetect(const sensorBus_t *bus)
 {
     uint8_t tmp;
 
-    mpu6500SpiInit(dev);
+    mpu6500SpiInit(bus);
 
-    mpu6500SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &tmp);
+    mpu6500SpiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &tmp);
 
     switch (tmp) {
     case MPU6500_WHO_AM_I_CONST:
@@ -117,7 +117,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    mpu6500SpiWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    mpu6500SpiWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -34,32 +34,32 @@
 #include "accgyro_mpu6500.h"
 #include "accgyro_spi_mpu6500.h"
 
-#define DISABLE_MPU6500       IOHi(spiCsnPin)
-#define ENABLE_MPU6500        IOLo(spiCsnPin)
+#define DISABLE_MPU6500(spiCsnPin)       IOHi(spiCsnPin)
+#define ENABLE_MPU6500(spiCsnPin)        IOLo(spiCsnPin)
 
 #define BIT_SLEEP                   0x40
 
-bool mpu6500SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
+bool mpu6500SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU6500;
+    ENABLE_MPU6500(spi->csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg);
     spiTransferByte(MPU6500_SPI_INSTANCE, data);
-    DISABLE_MPU6500;
+    DISABLE_MPU6500(spi->csnPin);
 
     return true;
 }
 
-bool mpu6500SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu6500SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU6500;
+    ENABLE_MPU6500(spi->csnPin);
     spiTransferByte(MPU6500_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU6500_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU6500;
+    DISABLE_MPU6500(spi->csnPin);
 
     return true;
 }
 
-static void mpu6500SpiInit(IO_t spiCsnPin)
+static void mpu6500SpiInit(const sensorSpi_t *spi)
 {
     static bool hardwareInitialised = false;
 
@@ -67,8 +67,8 @@ static void mpu6500SpiInit(IO_t spiCsnPin)
         return;
     }
 
-    IOInit(spiCsnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spiCsnPin, SPI_IO_CS_CFG);
+    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);
 
@@ -76,13 +76,13 @@ static void mpu6500SpiInit(IO_t spiCsnPin)
 }
 
 static uint8_t mpuDetected = MPU_NONE;
-uint8_t mpu6500SpiDetect(IO_t spiCsnPin)
+uint8_t mpu6500SpiDetect(const sensorSpi_t *spi)
 {
     uint8_t tmp;
 
-    mpu6500SpiInit(spiCsnPin);
+    mpu6500SpiInit(spi);
 
-    mpu6500SpiReadRegister(spiCsnPin, MPU_RA_WHO_AM_I, 1, &tmp);
+    mpu6500SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &tmp);
 
     switch (tmp) {
     case MPU6500_WHO_AM_I_CONST:
@@ -117,7 +117,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro)
     mpu6500GyroInit(gyro);
 
     // Disable Primary I2C Interface
-    mpu6500SpiWriteRegister(gyro->spi.csnPin, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    mpu6500SpiWriteRegister(&gyro->spi, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
 
     spiSetDivisor(MPU6500_SPI_INSTANCE, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -19,7 +19,7 @@
 
 #include "sensor.h"
 
-uint8_t mpu6500SpiDetect(const sensorBus_t *bus);
+bool mpu6500SpiDetect(const sensorBus_t *bus);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -17,15 +17,15 @@
 
 #pragma once
 
-#include "io_types.h"
+#include "sensor.h"
 
-uint8_t mpu6500SpiDetect(IO_t spiCsnPin);
+uint8_t mpu6500SpiDetect(const sensorSpi_t *spi);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6500SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
-bool mpu6500SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6500SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool mpu6500SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro);
 void mpu6500SpiAccInit(accDev_t *acc);

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -19,13 +19,13 @@
 
 #include "sensor.h"
 
-uint8_t mpu6500SpiDetect(const sensorSpi_t *spi);
+uint8_t mpu6500SpiDetect(const sensorDev_t *dev);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6500SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
-bool mpu6500SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6500SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool mpu6500SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro);
 void mpu6500SpiAccInit(accDev_t *acc);

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -19,13 +19,13 @@
 
 #include "sensor.h"
 
-uint8_t mpu6500SpiDetect(const sensorDev_t *dev);
+uint8_t mpu6500SpiDetect(const sensorBus_t *bus);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6500SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
-bool mpu6500SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6500SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool mpu6500SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro);
 void mpu6500SpiAccInit(accDev_t *acc);

--- a/src/main/drivers/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro_spi_mpu6500.h
@@ -17,13 +17,15 @@
 
 #pragma once
 
-uint8_t mpu6500SpiDetect(void);
+#include "io_types.h"
 
-void mpu6500SpiAccInit(accDev_t *acc);
-void mpu6500SpiGyroInit(gyroDev_t *gyro);
+uint8_t mpu6500SpiDetect(IO_t spiCsnPin);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu6500WriteRegister(uint8_t reg, uint8_t data);
-bool mpu6500ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu6500SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
+bool mpu6500SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
+
+void mpu6500SpiGyroInit(gyroDev_t *gyro);
+void mpu6500SpiAccInit(accDev_t *acc);

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -146,30 +146,30 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
 
-    mpu9250WriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250WriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
 
     //Fchoice_b defaults to 00 which makes fchoice 11
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
 
     if (gyro->lpf == 4) {
-        verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
     } else if (gyro->lpf < 4) {
-        verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
     } else if (gyro->lpf > 4) {
-        verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
     }
 
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
 
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    verifympu9250WriteRegister(gyro->spiCsnPin, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -57,41 +57,41 @@ void mpu9250SpiResetGyro(void)
 {
     // Device Reset
 #ifdef MPU9250_CS_PIN
-    sensorSpi_t spi = {.csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) };
-    mpu9250SpiWriteRegister(&spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    sensorBus_t bus = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
+    mpu9250SpiWriteRegister(&bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(150);
 #endif
 }
 
-bool mpu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
+bool mpu9250SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU9250(dev->spi.csnPin);
+    ENABLE_MPU9250(bus->spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg);
     spiTransferByte(MPU9250_SPI_INSTANCE, data);
-    DISABLE_MPU9250(dev->spi.csnPin);
+    DISABLE_MPU9250(bus->spi.csnPin);
     delayMicroseconds(1);
 
     return true;
 }
 
-bool mpu9250SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250(dev->spi.csnPin);
+    ENABLE_MPU9250(bus->spi.csnPin);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250(dev->spi.csnPin);
+    DISABLE_MPU9250(bus->spi.csnPin);
 
     return true;
 }
 
-bool mpu9250SlowReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SlowReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250(dev->spi.csnPin);
+    ENABLE_MPU9250(bus->spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250(dev->spi.csnPin);
+    DISABLE_MPU9250(bus->spi.csnPin);
     delayMicroseconds(1);
 
     return true;
@@ -120,21 +120,21 @@ void mpu9250SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 8;
 }
 
-bool verifympu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
+bool verifympu9250SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    mpu9250SpiWriteRegister(dev, reg, data);
+    mpu9250SpiWriteRegister(bus, reg, data);
     delayMicroseconds(100);
 
     do {
-        mpu9250SlowReadRegister(dev, reg, 1, &in);
+        mpu9250SlowReadRegister(bus, reg, 1, &in);
         if (in == data) {
             return true;
         } else {
             debug[3]++;
-            mpu9250SpiWriteRegister(dev, reg, data);
+            mpu9250SpiWriteRegister(bus, reg, data);
             delayMicroseconds(100);
         }
     } while (attemptsRemaining--);
@@ -149,30 +149,30 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
 
-    mpu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
 
     //Fchoice_b defaults to 00 which makes fchoice 11
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, raGyroConfigData);
 
     if (gyro->lpf == 4) {
-        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+        verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
     } else if (gyro->lpf < 4) {
-        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+        verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
     } else if (gyro->lpf > 4) {
-        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+        verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
     }
 
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
 
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    verifympu9250SpiWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);
@@ -180,21 +180,21 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     mpuSpi9250InitDone = true; //init done
 }
 
-bool mpu9250SpiDetect(const sensorDev_t *dev)
+bool mpu9250SpiDetect(const sensorBus_t *bus)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
+    IOInit(bus->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
-    mpu9250SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
 
     do {
         delay(150);
 
-        mpu9250SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &in);
+        mpu9250SpiReadRegister(bus, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -63,35 +63,35 @@ void mpu9250SpiResetGyro(void)
 #endif
 }
 
-bool mpu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool mpu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU9250(spi->csnPin);
+    ENABLE_MPU9250(dev->spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg);
     spiTransferByte(MPU9250_SPI_INSTANCE, data);
-    DISABLE_MPU9250(spi->csnPin);
+    DISABLE_MPU9250(dev->spi.csnPin);
     delayMicroseconds(1);
 
     return true;
 }
 
-bool mpu9250SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250(spi->csnPin);
+    ENABLE_MPU9250(dev->spi.csnPin);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250(spi->csnPin);
+    DISABLE_MPU9250(dev->spi.csnPin);
 
     return true;
 }
 
-bool mpu9250SlowReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SlowReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250(spi->csnPin);
+    ENABLE_MPU9250(dev->spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250(spi->csnPin);
+    DISABLE_MPU9250(dev->spi.csnPin);
     delayMicroseconds(1);
 
     return true;
@@ -120,21 +120,21 @@ void mpu9250SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 8;
 }
 
-bool verifympu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
+bool verifympu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    mpu9250SpiWriteRegister(spi, reg, data);
+    mpu9250SpiWriteRegister(dev, reg, data);
     delayMicroseconds(100);
 
     do {
-        mpu9250SlowReadRegister(spi, reg, 1, &in);
+        mpu9250SlowReadRegister(dev, reg, 1, &in);
         if (in == data) {
             return true;
         } else {
             debug[3]++;
-            mpu9250SpiWriteRegister(spi, reg, data);
+            mpu9250SpiWriteRegister(dev, reg, data);
             delayMicroseconds(100);
         }
     } while (attemptsRemaining--);
@@ -149,30 +149,30 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
 
-    mpu9250SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
 
     //Fchoice_b defaults to 00 which makes fchoice 11
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, raGyroConfigData);
 
     if (gyro->lpf == 4) {
-        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
     } else if (gyro->lpf < 4) {
-        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
     } else if (gyro->lpf > 4) {
-        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+        verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
     }
 
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
 
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    verifympu9250SpiWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);
@@ -180,21 +180,21 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     mpuSpi9250InitDone = true; //init done
 }
 
-bool mpu9250SpiDetect(const sensorSpi_t *spi)
+bool mpu9250SpiDetect(const sensorDev_t *dev)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
+    IOInit(dev->spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->spi.csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
-    mpu9250SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
 
     do {
         delay(150);
 
-        mpu9250SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &in);
+        mpu9250SpiReadRegister(dev, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro_spi_mpu9250.c
@@ -50,45 +50,48 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro);
 
 static bool mpuSpi9250InitDone = false;
 
-#define DISABLE_MPU9250       IOHi(spiCsnPin)
-#define ENABLE_MPU9250        IOLo(spiCsnPin)
+#define DISABLE_MPU9250(spiCsnPin)       IOHi(spiCsnPin)
+#define ENABLE_MPU9250(spiCsnPin)        IOLo(spiCsnPin)
 
-void mpu9250SpiResetGyro(IO_t spiCsnPin)
+void mpu9250SpiResetGyro(void)
 {
     // Device Reset
-    mpu9250WriteRegister(spiCsnPin, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+#ifdef MPU9250_CS_PIN
+    sensorSpi_t spi = {.csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) };
+    mpu9250SpiWriteRegister(&spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(150);
+#endif
 }
 
-bool mpu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
+bool mpu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
-    ENABLE_MPU9250;
+    ENABLE_MPU9250(spi->csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg);
     spiTransferByte(MPU9250_SPI_INSTANCE, data);
-    DISABLE_MPU9250;
+    DISABLE_MPU9250(spi->csnPin);
     delayMicroseconds(1);
 
     return true;
 }
 
-bool mpu9250SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250;
+    ENABLE_MPU9250(spi->csnPin);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250;
+    DISABLE_MPU9250(spi->csnPin);
 
     return true;
 }
 
-bool mpu9250SlowReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data)
+bool mpu9250SlowReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data)
 {
-    ENABLE_MPU9250;
+    ENABLE_MPU9250(spi->csnPin);
     delayMicroseconds(1);
     spiTransferByte(MPU9250_SPI_INSTANCE, reg | 0x80); // read transaction
     spiTransfer(MPU9250_SPI_INSTANCE, data, NULL, length);
-    DISABLE_MPU9250;
+    DISABLE_MPU9250(spi->csnPin);
     delayMicroseconds(1);
 
     return true;
@@ -117,21 +120,21 @@ void mpu9250SpiAccInit(accDev_t *acc)
     acc->acc_1G = 512 * 8;
 }
 
-bool verifympu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data)
+bool verifympu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    mpu9250WriteRegister(reg, data);
+    mpu9250SpiWriteRegister(spi, reg, data);
     delayMicroseconds(100);
 
     do {
-        mpu9250SlowReadRegister(reg, 1, &in);
+        mpu9250SlowReadRegister(spi, reg, 1, &in);
         if (in == data) {
             return true;
         } else {
             debug[3]++;
-            mpu9250SpiWriteRegister(spiCsnPin, reg, data);
+            mpu9250SpiWriteRegister(spi, reg, data);
             delayMicroseconds(100);
         }
     } while (attemptsRemaining--);
@@ -146,30 +149,30 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed for writing to slow registers
 
-    mpu9250WriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
 
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
 
     //Fchoice_b defaults to 00 which makes fchoice 11
     const uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_8_kHz ? (INV_FSR_2000DPS << 3 | FCB_3600_32) : (INV_FSR_2000DPS << 3 | FCB_DISABLED);
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_GYRO_CONFIG, raGyroConfigData);
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_GYRO_CONFIG, raGyroConfigData);
 
     if (gyro->lpf == 4) {
-        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
+        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 1); //1KHz, 184DLPF
     } else if (gyro->lpf < 4) {
-        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
+        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 7); //8KHz, 3600DLPF
     } else if (gyro->lpf > 4) {
-        verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
+        verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_CONFIG, 0); //8KHz, 250DLPF
     }
 
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_SMPLRT_DIV, gyroMPU6xxxGetDividerDrops(gyro));
 
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_ACCEL_CONFIG, INV_FSR_8G << 3);
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    verifympu9250WriteRegister(gyro->spi.csnPin, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    verifympu9250SpiWriteRegister(&gyro->spi, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_FAST);
@@ -177,25 +180,21 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     mpuSpi9250InitDone = true; //init done
 }
 
-bool mpu9250SpiDetect(IO_t mpuCsPin)
+bool mpu9250SpiDetect(const sensorSpi_t *spi)
 {
     uint8_t in;
     uint8_t attemptsRemaining = 20;
 
-    /* not the best place for this - should really have an init method */
-#ifdef MPU9250_CS_PIN
-    mpuSpi9250CsPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN));
-#endif
-    IOInit(mpuSpi9250CsPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(mpuSpi9250CsPin, SPI_IO_CS_CFG);
+    IOInit(spi->csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(spi->csnPin, SPI_IO_CS_CFG);
 
     spiSetDivisor(MPU9250_SPI_INSTANCE, SPI_CLOCK_INITIALIZATON); //low speed
-    mpu9250WriteRegister(MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    mpu9250SpiWriteRegister(spi, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
 
     do {
         delay(150);
 
-        mpu9250ReadRegister(MPU_RA_WHO_AM_I, 1, &in);
+        mpu9250SpiReadRegister(spi, MPU_RA_WHO_AM_I, 1, &in);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -28,12 +28,12 @@
 
 void mpu9250SpiResetGyro(void);
 
-bool mpu9250SpiDetect(const sensorSpi_t *spi);
+bool mpu9250SpiDetect(const sensorDev_t *dev);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
-bool verifympu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
-bool mpu9250SpiSlowReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool verifympu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiSlowReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -28,12 +28,12 @@
 
 void mpu9250SpiResetGyro(void);
 
-bool mpu9250SpiDetect(const sensorDev_t *dev);
+bool mpu9250SpiDetect(const sensorBus_t *bus);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
-bool verifympu9250SpiWriteRegister(const sensorDev_t *dev, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
-bool mpu9250SpiSlowReadRegister(const sensorDev_t *dev, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool verifympu9250SpiWriteRegister(const sensorBus_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiSlowReadRegister(const sensorBus_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "io_types.h"
+
 #define mpu9250_CONFIG                      0x1A
 
 /* We should probably use these. :)
@@ -24,14 +26,14 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-void mpu9250ResetGyro(void);
+void mpu9250SpiResetGyro(IO_t spiCsnPin);
 
-bool mpu9250SpiDetect(void);
+bool mpu9250SpiDetect(IO_t spiCsnPin);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250WriteRegister(uint8_t reg, uint8_t data);
-bool verifympu9250WriteRegister(uint8_t reg, uint8_t data);
-bool mpu9250ReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
-bool mpu9250SlowReadRegister(uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
+bool verifympu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiSlowReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro_spi_mpu9250.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "io_types.h"
+#include "sensor.h"
 
 #define mpu9250_CONFIG                      0x1A
 
@@ -26,14 +26,14 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-void mpu9250SpiResetGyro(IO_t spiCsnPin);
+void mpu9250SpiResetGyro(void);
 
-bool mpu9250SpiDetect(IO_t spiCsnPin);
+bool mpu9250SpiDetect(const sensorSpi_t *spi);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
-bool verifympu9250SpiWriteRegister(IO_t spiCsnPin, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
-bool mpu9250SpiSlowReadRegister(IO_t spiCsnPin, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool verifympu9250SpiWriteRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiSlowReadRegister(const sensorSpi_t *spi, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/compass.h
+++ b/src/main/drivers/compass.h
@@ -22,7 +22,7 @@
 typedef struct magDev_s {
     sensorInitFuncPtr init;                                 // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function
-    sensorSpi_t spi;
+    sensorDev_t dev;
     sensor_align_e magAlign;
 } magDev_t;
 

--- a/src/main/drivers/compass.h
+++ b/src/main/drivers/compass.h
@@ -22,7 +22,7 @@
 typedef struct magDev_s {
     sensorInitFuncPtr init;                                 // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function
-    sensorDev_t dev;
+    sensorBus_t bus;
     sensor_align_e magAlign;
 } magDev_t;
 

--- a/src/main/drivers/compass.h
+++ b/src/main/drivers/compass.h
@@ -22,7 +22,7 @@
 typedef struct magDev_s {
     sensorInitFuncPtr init;                                 // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function
-    IO_t spiCsnPin;
+    sensorSpi_t spi;
     sensor_align_e magAlign;
 } magDev_t;
 

--- a/src/main/drivers/compass.h
+++ b/src/main/drivers/compass.h
@@ -22,6 +22,7 @@
 typedef struct magDev_s {
     sensorInitFuncPtr init;                                 // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function
+    IO_t spiCsnPin;
     sensor_align_e magAlign;
 } magDev_t;
 

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -316,13 +316,13 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    verifympu9250SpiWriteRegister(&mag->bus, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -316,13 +316,13 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    verifympu9250SpiWriteRegister(&mag->dev, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -86,9 +86,9 @@ static float magGain[3] = { 1.0f, 1.0f, 1.0f };
 // Is an separate MPU9250 driver really needed? The GYRO/ACC part between MPU6500 and MPU9250 is exactly the same.
 #if defined(MPU6500_SPI_INSTANCE) && !defined(MPU9250_SPI_INSTANCE)
 #define MPU9250_SPI_INSTANCE
-#define verifympu9250WriteRegister mpu6500WriteRegister
-#define mpu9250WriteRegister mpu6500WriteRegister
-#define mpu9250ReadRegister mpu6500ReadRegister
+#define verifympu9250SpiWriteRegister mpu6500SpiWriteRegister
+#define mpu9250SpiWriteRegister mpu6500SpiWriteRegister
+#define mpu9250SpiReadRegister mpu6500SpiReadRegister
 #endif
 
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
@@ -109,22 +109,22 @@ static queuedReadState_t queuedRead = { false, 0, 0};
 
 static bool ak8963SensorRead(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf)
 {
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
     delay(10);
     __disable_irq();
-    mpu9250ReadRegister(MPU_RA_EXT_SENS_DATA_00, len_, buf);               // read I2C
+    mpuI2CReadRegister(MPU_RA_EXT_SENS_DATA_00, len_, buf);         // read I2C
     __enable_irq();
     return true;
 }
 
 static bool ak8963SensorWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
     return true;
 }
 
@@ -136,9 +136,9 @@ static bool ak8963SensorStartRead(uint8_t addr_, uint8_t reg_, uint8_t len_)
 
     queuedRead.len = len_;
 
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    verifympu9250WriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
 
     queuedRead.readStartedAt = micros();
     queuedRead.waiting = true;
@@ -173,7 +173,7 @@ static bool ak8963SensorCompleteRead(uint8_t *buf)
 
     queuedRead.waiting = false;
 
-    mpu9250ReadRegister(MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
+    mpuI2CReadRegister(MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
     return true;
 }
 #else
@@ -316,13 +316,13 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250WriteRegister(MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
     delay(10);
 
-    verifympu9250WriteRegister(MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250WriteRegister(MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -316,13 +316,13 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
     delay(10);
 
-    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    verifympu9250SpiWriteRegister(&mag->spi, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -109,22 +109,22 @@ static queuedReadState_t queuedRead = { false, 0, 0};
 
 static bool ak8963SensorRead(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf)
 {
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
     delay(10);
     __disable_irq();
-    mpuI2CReadRegister(MPU_RA_EXT_SENS_DATA_00, len_, buf);         // read I2C
+    mpuReadRegisterI2C(NULL, MPU_RA_EXT_SENS_DATA_00, len_, buf);         // read I2C
     __enable_irq();
     return true;
 }
 
 static bool ak8963SensorWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
 {
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_ADDR, addr_);               // set I2C slave address for write
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_DO, data);                  // set I2C salve value
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_CTRL, 0x81);                // write 1 byte
     return true;
 }
 
@@ -136,9 +136,9 @@ static bool ak8963SensorStartRead(uint8_t addr_, uint8_t reg_, uint8_t len_)
 
     queuedRead.len = len_;
 
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
-    mpuI2CWriteRegister(MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_ADDR, addr_ | READ_FLAG);   // set I2C slave address for read
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_REG, reg_);                 // set I2C slave register
+    mpuWriteRegisterI2C(NULL, MPU_RA_I2C_SLV0_CTRL, len_ | 0x80);         // read number of bytes
 
     queuedRead.readStartedAt = micros();
     queuedRead.waiting = true;
@@ -173,7 +173,7 @@ static bool ak8963SensorCompleteRead(uint8_t *buf)
 
     queuedRead.waiting = false;
 
-    mpuI2CReadRegister(MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
+    mpuReadRegisterI2C(NULL, MPU_RA_EXT_SENS_DATA_00, queuedRead.len, buf);               // read I2C buffer
     return true;
 }
 #else

--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -316,13 +316,13 @@ bool ak8963Detect(magDev_t *mag)
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)
     // initialze I2C master via SPI bus (MPU9250)
 
-    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
+    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_INT_PIN_CFG, 0x10);               // INT_ANYRD_2CLEAR
     delay(10);
 
-    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
+    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_I2C_MST_CTRL, 0x0D);              // I2C multi-master / 400kHz
     delay(10);
 
-    verifympu9250SpiWriteRegister(mag->spiCsnPin, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
+    verifympu9250SpiWriteRegister(mag->spi.csnPin, MPU_RA_USER_CTRL, 0x30);                 // I2C master mode, SPI mode only
     delay(10);
 #endif
 

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -34,9 +34,11 @@ typedef enum {
     CW270_DEG_FLIP = 8
 } sensor_align_e;
 
-typedef struct sensorSpi_s {
-    IO_t csnPin;
-} sensorSpi_t;
+typedef union sensorDev_u {
+    struct sensorSpi_s {
+        IO_t csnPin;
+    } spi;
+} sensorDev_t;
 
 typedef bool (*sensorInitFuncPtr)(void);                    // sensor init prototype
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read and align prototype

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -34,11 +34,11 @@ typedef enum {
     CW270_DEG_FLIP = 8
 } sensor_align_e;
 
-typedef union sensorDev_u {
+typedef union sensorBus_u {
     struct sensorSpi_s {
         IO_t csnPin;
     } spi;
-} sensorDev_t;
+} sensorBus_t;
 
 typedef bool (*sensorInitFuncPtr)(void);                    // sensor init prototype
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read and align prototype

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "io_types.h"
+
 typedef enum {
     ALIGN_DEFAULT = 0,                                      // driver-provided alignment
     CW0_DEG = 1,
@@ -31,6 +33,10 @@ typedef enum {
     CW180_DEG_FLIP = 7,
     CW270_DEG_FLIP = 8
 } sensor_align_e;
+
+typedef struct sensorSpi_s {
+    IO_t csnPin;
+} sensorSpi_t;
 
 typedef bool (*sensorInitFuncPtr)(void);                    // sensor init prototype
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read and align prototype

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -509,6 +509,9 @@ static const clivalue_t valueTable[] = {
 #if defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20689)
     { "gyro_use_32khz",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_use_32khz) },
 #endif
+#if defined(USE_DUAL_GYRO)
+    { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,    1 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
+#endif
 #if defined(USE_MPU_DATA_READY_SIGNAL)
     { "gyro_isr_update",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_isr_update) },
 #endif
@@ -998,6 +1001,9 @@ static const clivalue_t valueTable[] = {
     { "gyro_sync_denom",            VAR_UINT8  | MASTER_VALUE,  &gyroConfig()->gyro_sync_denom, .config.minmax = { 1,  32 } },
 #if defined(GYRO_USES_SPI) && defined(USE_MPU_DATA_READY_SIGNAL)
     { "gyro_isr_update",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &gyroConfig()->gyro_isr_update, .config.lookup = { TABLE_OFF_ON } },
+#endif
+#if defined(USE_DUAL_GYRO)
+    { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE, &gyroConfig()->gyro_to_use, .config.minmax = { 0,    1 } }, 
 #endif
     { "gyro_use_32khz",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &gyroConfig()->gyro_use_32khz, .config.lookup = { TABLE_OFF_ON } },
     { "gyro_lowpass_type",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &gyroConfig()->gyro_soft_lpf_type, .config.lookup = { TABLE_LOWPASS_TYPE } },

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -36,9 +36,10 @@
 #include "fc/config.h"
 #include "fc/runtime_config.h"
 
-#include "sensors/sensors.h"
 #include "sensors/boardalignment.h"
 #include "sensors/compass.h"
+#include "sensors/gyro.h"
+#include "sensors/sensors.h"
 
 #ifdef USE_HARDWARE_REVISION_DETECTION
 #include "hardware_revision.h"
@@ -144,6 +145,9 @@ bool compassInit(void)
     if (!compassDetect(&magDev, compassConfig()->mag_hardware)) {
         return false;
     }
+    // copy over SPI CS pin for AK8963 compass
+    magDev.spiCsnPin = gyroSpiCsnPin();
+
     const int16_t deg = compassConfig()->mag_declination / 100;
     const int16_t min = compassConfig()->mag_declination % 100;
     mag.magneticDeclination = (deg + ((float)min * (1.0f / 60.0f))) * 10; // heading is in 0.1deg units

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -146,7 +146,7 @@ bool compassInit(void)
         return false;
     }
     // copy over SPI CS pin for AK8963 compass
-    magDev.spi.csnPin = gyroSpiCsnPin();
+    magDev.dev.spi.csnPin = gyroSpiCsnPin();
 
     const int16_t deg = compassConfig()->mag_declination / 100;
     const int16_t min = compassConfig()->mag_declination % 100;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -146,7 +146,7 @@ bool compassInit(void)
         return false;
     }
     // copy over SPI CS pin for AK8963 compass
-    magDev.dev.spi.csnPin = gyroSpiCsnPin();
+    magDev.bus.spi.csnPin = gyroSpiCsnPin();
 
     const int16_t deg = compassConfig()->mag_declination / 100;
     const int16_t min = compassConfig()->mag_declination % 100;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -146,7 +146,7 @@ bool compassInit(void)
         return false;
     }
     // copy over SPI CS pin for AK8963 compass
-    magDev.spiCsnPin = gyroSpiCsnPin();
+    magDev.spi.csnPin = gyroSpiCsnPin();
 
     const int16_t deg = compassConfig()->mag_declination / 100;
     const int16_t min = compassConfig()->mag_declination % 100;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -127,7 +127,7 @@ static const extiConfig_t *selectMPUIntExtiConfig(void)
 
 IO_t gyroSpiCsnPin(void)
 {
-    return gyroDev0.spi.csnPin;
+    return gyroDev0.dev.spi.csnPin;
 }
 
 const mpuConfiguration_t *gyroMpuConfiguration(void)

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -122,6 +122,11 @@ static const extiConfig_t *selectMPUIntExtiConfig(void)
 }
 #endif
 
+IO_t gyroSpiCsnPin(void)
+{
+    return gyroDev0.spiCsnPin;
+}
+
 const mpuConfiguration_t *gyroMpuConfiguration(void)
 {
     return &gyroDev0.mpuConfiguration;
@@ -283,7 +288,7 @@ bool gyroInit(void)
     memset(&gyro, 0, sizeof(gyro));
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20689)
     gyroDev0.mpuIntExtiConfig = selectMPUIntExtiConfig();
-    mpuDetect(&gyroDev0);
+    mpuDetect(&gyroDev0, IO_NONE);
     mpuResetFn = gyroDev0.mpuConfiguration.resetFn;
 #endif
     const gyroSensor_e gyroHardware = gyroDetect(&gyroDev0);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -291,11 +291,15 @@ bool gyroInit(void)
     memset(&gyro, 0, sizeof(gyro));
 #if defined(USE_GYRO_MPU6050) || defined(USE_GYRO_MPU3050) || defined(USE_GYRO_MPU6500) || defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU6000) || defined(USE_ACC_MPU6050) || defined(USE_GYRO_SPI_MPU9250) || defined(USE_GYRO_SPI_ICM20689)
     gyroDev0.mpuIntExtiConfig = selectMPUIntExtiConfig();
+
+    sensorBus_t bus;
 #ifdef USE_DUAL_GYRO
-    mpuDetect(&gyroDev0, gyroConfig()->gyro_to_use == 0 ? : GYRO_0_CS_PIN ? GYRO_1_CS_PIN));
+    bus.spi.csnPin = gyroConfig()->gyro_to_use == 0 ? IOGetByTag(IO_TAG(GYRO_0_CS_PIN)) : IOGetByTag(IO_TAG(GYRO_1_CS_PIN));
 #else
-    mpuDetect(&gyroDev0, IO_NONE);
+    bus.spi.csnPin = IO_NONE;
 #endif // USE_DUAL_GYRO
+    mpuDetect(&gyroDev0, &bus);
+
     mpuResetFn = gyroDev0.mpuConfiguration.resetFn; // must be set after mpuDetect
 #endif
     const gyroSensor_e gyroHardware = gyroDetect(&gyroDev0);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -124,7 +124,7 @@ static const extiConfig_t *selectMPUIntExtiConfig(void)
 
 IO_t gyroSpiCsnPin(void)
 {
-    return gyroDev0.spiCsnPin;
+    return gyroDev0.spi.csnPin;
 }
 
 const mpuConfiguration_t *gyroMpuConfiguration(void)

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -127,7 +127,7 @@ static const extiConfig_t *selectMPUIntExtiConfig(void)
 
 IO_t gyroSpiCsnPin(void)
 {
-    return gyroDev0.dev.spi.csnPin;
+    return gyroDev0.bus.spi.csnPin;
 }
 
 const mpuConfiguration_t *gyroMpuConfiguration(void)

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -19,6 +19,7 @@
 
 #include "config/parameter_group.h"
 #include "common/axis.h"
+#include "drivers/io_types.h"
 #include "drivers/sensor.h"
 
 typedef enum {
@@ -65,6 +66,7 @@ PG_DECLARE(gyroConfig_t, gyroConfig);
 bool gyroInit(void);
 void gyroInitFilters(void);
 void gyroUpdate(void);
+IO_t gyroSpiCsnPin(void);
 struct mpuConfiguration_s;
 const struct mpuConfiguration_s *gyroMpuConfiguration(void);
 struct mpuDetectionResult_s;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -55,6 +55,7 @@ typedef struct gyroConfig_s {
     uint8_t  gyro_soft_lpf_hz;
     bool     gyro_isr_update;
     bool     gyro_use_32khz;
+    uint8_t  gyro_to_use;
     uint16_t gyro_soft_notch_hz_1;
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;


### PR DESCRIPTION
This is the version with only the following changes:

- Fixed `bus` parameter to `mpuDetect`.
- `mpu6500SpiDetect` to return `bool`.
- `mpu6500{Acc,Gyro}Detect` not to use `mpuDetected`.

This is what `status` shows:
```
CPU Clock=168MHz, GYRO=MPU6500, ACC=MPU6500
```

While this is when return value from `mpu6500SpiDetect` is honored.
```
CPU Clock=168MHz, GYRO=ICM20608G, ACC=ICM20608G
```